### PR TITLE
Proposition d'article : Conseil d'État genevois rejette les deux lois dites "corsets"

### DIFF
--- a/article/conseil-d-tat-genevois-rejette-les-deux-lois-dites-corsets.html
+++ b/article/conseil-d-tat-genevois-rejette-les-deux-lois-dites-corsets.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Conseil d'État genevois rejette les deux lois dites "corsets" | L’Horizon Libre</title>
+    
+    <link rel="icon" href="data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='48' fill='%23B91C1C' stroke='%23111827' stroke-width='2'/%3E%3Cg transform='translate(50, 50) scale(0.65) translate(-55, -55)'%3E%3Cpath d='M 10 85 Q 55 100 85 25 Q 70 50 50 55 Q 25 75 10 85 Z' fill='white'/%3E%3Cpath d='M 78 32 Q 95 25 95 15 L 85 25 Z' fill='%231E40AF'/%3E%3C/g%3E%3C/svg%3E">
+    
+  <meta name="description" content="Le Conseil d'État genevois rejette deux projets de loi visant à encadrer les dépenses publiques, suscitant un débat sur la gestion des finances publiques du canton et les risques d'une limitation trop stricte des dépenses.">
+  <meta name="category" content="politique">
+  <meta name="keywords" content="Conseil d'État, Genève, finances publiques, lois corsets, déficit budgétaire">
+  <meta property="og:title" content="Conseil d'État genevois rejette les deux lois dites "corsets"">
+  <meta property="og:description" content="Le Conseil d'État genevois rejette deux projets de loi visant à encadrer les dépenses publiques, suscitant un débat sur la gestion des finances publiques du canton et les risques d'une limitation trop stricte des dépenses.">
+
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <script src="https://unpkg.com/feather-icons"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; scroll-behavior: smooth; }
+        .article-card-img { height: 12rem; width: 100%; object-fit: cover; }
+        /* Ajoute ici d'autres styles globaux si tu le souhaites */
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    
+    <header class="bg-white shadow-sm sticky top-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-2">
+                <div class="flex items-center">
+                    <a href="/" title="Accueil - L'Horizon Libre">
+                        <svg class="h-14 sm:h-16 w-auto" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+                            <defs><style> .serif-final { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 20px; fill: #111827;} </style></defs>
+                            <rect y="50" width="200" height="4" fill="#1E40AF"/>
+                            <circle cx="100" cy="50" r="30" fill="#B91C1C"/>
+                            <g transform="translate(100, 50) scale(0.5) translate(-55, -55)">
+                                <path d="M 10 85 Q 55 100 85 25 Q 70 50 50 55 Q 25 75 10 85 Z" fill="white"/>
+                                <path d="M 78 32 Q 95 25 95 15 L 85 25 Z" fill="#1E40AF"/>
+                            </g>
+                            <text x="50" y="85" class="serif-final">L'Horizon Libre</text>
+                        </svg>
+                    </a>
+                </div>
+                <nav class="hidden md:flex items-center space-x-8">
+                    <a href="/" class="text-gray-600 hover:text-blue-800 transition">Accueil</a>
+                    <a href="/politique.html" class="text-gray-600 hover:text-blue-800 transition">Politique</a>
+                    <a href="/culture.html" class="text-gray-600 hover:text-blue-800 transition">Culture</a>
+                    <a href="/technologie.html" class="text-gray-600 hover:text-blue-800 transition">Tech</a>
+                    <a href="/a-propos.html" class="text-gray-600 hover:text-blue-800 transition">À Propos</a>
+                    <a href="/contact.html" class="text-gray-600 hover:text-blue-800 transition">Contact</a>
+                </nav>
+                <div><a href="#newsletter" class="bg-blue-800 text-white px-4 py-2 rounded-lg hover:bg-blue-900 transition text-sm font-semibold">Newsletter</a></div>
+            </div>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
+        
+<div class="max-w-4xl mx-auto">
+    <article>
+      <header class="mb-8 text-center">
+        <h1 class="text-3xl md:text-5xl font-bold">Conseil d'État genevois rejette les deux lois dites "corsets"</h1>
+        <p class="text-lg text-gray-600 mt-4">Le Conseil d'État genevois a opposé son veto aux deux lois visant à encadrer les dépenses publiques, qualifiées de "corsets" par leurs détracteurs.  Ces décisions s'inscrivent dans un contexte de débats budgétaires tendus et soulèvent des questions sur l'avenir des finances publiques genevoises.</p>
+        <time class="text-sm text-gray-500 mt-4 block" datetime="2025-08-20T15:48:42.906635+00:00">20 August 2025</time>
+      </header>
+      
+      
+      <figure class="my-8">
+        <img src="https://images.unsplash.com/photo-1538847631723-0bd26d2a28e8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3OTI2MjN8MHwxfHNlYXJjaHwxfHxDb25zZWlsJTIwZCUyNyVDMyU4OXRhdCUyMGdlbmV2b2lzJTIwcmVqZXR0ZSUyMGxlcyUyMGRldXglMjBsb2lzJTIwZGl0ZXMlMjAlMjJjb3JzZXRzJTIyfGVufDB8fHx8MTc1NTcwNDkyMnww&ixlib=rb-4.1.0&q=80&w=1080" alt="Conseil d'État genevois rejette les deux lois dites "corsets"" class="article-featured-image shadow-lg">
+        <figcaption class="text-xs text-gray-500 text-center mt-2">
+          Photo par <a href="https://unsplash.com/@albertobigoni">Alberto Bigoni</a> sur <a href="https://unsplash.com">Unsplash</a>
+        </figcaption>
+      </figure>
+      
+
+      <section class="prose prose-lg max-w-none">
+        <p>Le Conseil d'État genevois a annoncé son refus d'avaliser deux projets de loi visant à encadrer les dépenses publiques, souvent qualifiés de "lois corsets".  Ces décisions, rendues publiques récemment, marquent un tournant dans les débats budgétaires en cours au sein du canton.  Les deux projets, soutenus par une partie de la population et certains partis politiques, visaient à imposer des limites strictes aux dépenses publiques afin de maîtriser le déficit budgétaire.</p><p>Le Conseil d'État justifie son refus en soulignant les risques potentiels liés à une limitation trop stricte des dépenses.  Selon le gouvernement cantonal, ces mesures pourraient entraver la réalisation de projets importants pour le développement économique et social du canton.  Il est également avancé que la rigidité de ces lois pourrait nuire à la capacité d'adaptation du canton face aux imprévus et aux évolutions de la conjoncture économique.  Des alternatives, plus souples et moins contraignantes, sont suggérées par le Conseil d'État pour assurer une gestion responsable des finances publiques.</p><p>Cette décision suscite des réactions contrastées.  Si certains saluent la prudence du Conseil d'État et la volonté de préserver la flexibilité budgétaire, d'autres déplorent un manque d'ambition dans la lutte contre le déficit.  Les débats parlementaires qui suivront devraient être animés, et l'avenir de la gestion des finances publiques genevoises reste incertain.  L'opposition, quant à elle, promet de maintenir la pression pour une meilleure maîtrise des dépenses publiques.</p><p>En conclusion, le rejet de ces deux lois par le Conseil d'État genevois ouvre un nouveau chapitre dans le débat sur les finances publiques du canton.  Les prochaines étapes parlementaires seront cruciales pour déterminer la suite des événements et les mesures concrètes qui seront prises pour assurer la stabilité financière de Genève.</p>
+      </section>
+
+      
+      <section class="key-points mt-12 p-6 bg-gray-100 rounded-lg">
+        <h3 class="text-2xl font-bold mb-4">Points clés</h3>
+        <ul class="list-disc list-inside space-y-2">
+          
+          <li>Le Conseil d'État genevois a rejeté deux projets de loi visant à limiter les dépenses publiques.</li>
+          
+          <li>Le gouvernement cantonal craint que ces lois, qualifiées de "corsets", nuisent au développement économique et social du canton.</li>
+          
+          <li>Des débats parlementaires animés sont attendus suite à cette décision.</li>
+          
+        </ul>
+      </section>
+      
+    </article>
+</div>
+
+    </main>
+
+    <footer id="footer" class="bg-gray-800 text-gray-300 mt-16">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
+                </div>
+            <div class="mt-8 border-t border-gray-700 pt-8 flex justify-between items-center">
+                <p class="text-sm text-gray-500">&copy; 2025 L'Horizon Libre. Tous droits réservés.</p>
+                <div class="flex space-x-4"><a href="https://x.com/MediaHorizonL" class="text-gray-400 hover:text-white"><i data-feather="twitter"></i></a></div>
+            </div>
+        </div>
+    </footer>
+    
+    <script>
+        feather.replace();
+        // ... ajoute ici le reste de tes scripts globaux ...
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Cet article a été généré automatiquement par Aurore et sera fusionné dans 30 secondes.