### PR TITLE
Proposition d'article : États-Unis: Hausse des prix pour PlayStation et PepsiCo face aux droits de douane

### DIFF
--- a/article/tats-unis-hausse-des-prix-pour-playstation-et-pepsico-face-aux-droits-de-douane.html
+++ b/article/tats-unis-hausse-des-prix-pour-playstation-et-pepsico-face-aux-droits-de-douane.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>États-Unis: Hausse des prix pour PlayStation et PepsiCo face aux droits de douane | L’Horizon Libre</title>
+    
+    <link rel="icon" href="data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='48' fill='%23B91C1C' stroke='%23111827' stroke-width='2'/%3E%3Cg transform='translate(50, 50) scale(0.65) translate(-55, -55)'%3E%3Cpath d='M 10 85 Q 55 100 85 25 Q 70 50 50 55 Q 25 75 10 85 Z' fill='white'/%3E%3Cpath d='M 78 32 Q 95 25 95 15 L 85 25 Z' fill='%231E40AF'/%3E%3C/g%3E%3C/svg%3E">
+    
+  <meta name="description" content="Sony et PepsiCo augmentent leurs prix aux États-Unis en raison des droits de douane imposés par l'administration américaine.  Cette décision impacte les consommateurs et reflète les tensions commerciales internationales.">
+  <meta name="category" content="économie">
+  <meta name="keywords" content="droits de douane, inflation, PlayStation, PepsiCo, États-Unis">
+  <meta property="og:title" content="États-Unis: Hausse des prix pour PlayStation et PepsiCo face aux droits de douane">
+  <meta property="og:description" content="Sony et PepsiCo augmentent leurs prix aux États-Unis en raison des droits de douane imposés par l'administration américaine.  Cette décision impacte les consommateurs et reflète les tensions commerciales internationales.">
+
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <script src="https://unpkg.com/feather-icons"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; scroll-behavior: smooth; }
+        .article-card-img { height: 12rem; width: 100%; object-fit: cover; }
+        /* Ajoute ici d'autres styles globaux si tu le souhaites */
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    
+    <header class="bg-white shadow-sm sticky top-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-2">
+                <div class="flex items-center">
+                    <a href="/" title="Accueil - L'Horizon Libre">
+                        <svg class="h-14 sm:h-16 w-auto" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+                            <defs><style> .serif-final { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 20px; fill: #111827;} </style></defs>
+                            <rect y="50" width="200" height="4" fill="#1E40AF"/>
+                            <circle cx="100" cy="50" r="30" fill="#B91C1C"/>
+                            <g transform="translate(100, 50) scale(0.5) translate(-55, -55)">
+                                <path d="M 10 85 Q 55 100 85 25 Q 70 50 50 55 Q 25 75 10 85 Z" fill="white"/>
+                                <path d="M 78 32 Q 95 25 95 15 L 85 25 Z" fill="#1E40AF"/>
+                            </g>
+                            <text x="50" y="85" class="serif-final">L'Horizon Libre</text>
+                        </svg>
+                    </a>
+                </div>
+                <nav class="hidden md:flex items-center space-x-8">
+                    <a href="/" class="text-gray-600 hover:text-blue-800 transition">Accueil</a>
+                    <a href="/politique.html" class="text-gray-600 hover:text-blue-800 transition">Politique</a>
+                    <a href="/culture.html" class="text-gray-600 hover:text-blue-800 transition">Culture</a>
+                    <a href="/technologie.html" class="text-gray-600 hover:text-blue-800 transition">Tech</a>
+                    <a href="/a-propos.html" class="text-gray-600 hover:text-blue-800 transition">À Propos</a>
+                    <a href="/contact.html" class="text-gray-600 hover:text-blue-800 transition">Contact</a>
+                </nav>
+                <div><a href="#newsletter" class="bg-blue-800 text-white px-4 py-2 rounded-lg hover:bg-blue-900 transition text-sm font-semibold">Newsletter</a></div>
+            </div>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
+        
+<div class="max-w-4xl mx-auto">
+    <article>
+      <header class="mb-8 text-center">
+        <h1 class="text-3xl md:text-5xl font-bold">États-Unis: Hausse des prix pour PlayStation et PepsiCo face aux droits de douane</h1>
+        <p class="text-lg text-gray-600 mt-4">Sony augmente le prix de ses consoles PlayStation 5 aux États-Unis de 50 dollars, tandis que PepsiCo prévoit une hausse d'environ 10% sur ses boissons gazeuses.  Ces augmentations sont imputées aux droits de douane américains.</p>
+        <time class="text-sm text-gray-500 mt-4 block" datetime="2025-08-21T08:15:19.053992+00:00">21 August 2025</time>
+      </header>
+      
+      
+      <figure class="my-8">
+        <img src="https://images.unsplash.com/photo-1616474838095-e402ae602e7a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3OTI2MjN8MHwxfHNlYXJjaHwxfHwlQzMlODl0YXRzLVVuaXMlM0ElMjBIYXVzc2UlMjBkZXMlMjBwcml4JTIwcG91ciUyMFBsYXlTdGF0aW9uJTIwZXQlMjBQZXBzaUNvJTIwZmFjZSUyMGF1eCUyMGRyb2l0cyUyMGRlJTIwZG91YW5lfGVufDB8fHx8MTc1NTc2NDExOXww&ixlib=rb-4.1.0&q=80&w=1080" alt="États-Unis: Hausse des prix pour PlayStation et PepsiCo face aux droits de douane" class="article-featured-image shadow-lg">
+        <figcaption class="text-xs text-gray-500 text-center mt-2">
+          Photo par <a href="https://unsplash.com/@jakobnoahrosen">Jakob Rosen</a> sur <a href="https://unsplash.com">Unsplash</a>
+        </figcaption>
+      </figure>
+      
+
+      <section class="prose prose-lg max-w-none">
+        <p>Face à la hausse des droits de douane américains, plusieurs grandes entreprises américaines annoncent des augmentations de prix. Sony a confirmé une augmentation de 50 dollars pour ses consoles PlayStation 5 aux États-Unis, portant le prix de la PS5 à 550 dollars et celui de la PS5 Digital Edition à 750 dollars. Cette décision, effective à partir du 21 août, est justifiée par l'environnement économique difficile et l'impact des droits de douane sur les coûts de production.</p><p>PepsiCo, géant américain des boissons et snacks, envisage quant à lui une augmentation des prix de ses boissons gazeuses d'environ 10%.  Cette hausse vise à compenser les surcoûts liés aux droits de douane, notamment sur l'aluminium utilisé dans la fabrication des canettes.  D'autres entreprises, comme Monster Beverages, envisagent également des augmentations de prix pour faire face à ce contexte économique défavorable.</p><p>Ces augmentations de prix s'inscrivent dans un contexte plus large de hausse des tarifs douaniers imposés par les États-Unis à de nombreux pays.  Ces droits de douane, qui peuvent atteindre jusqu'à 50% selon les produits, affectent divers secteurs, des jeux vidéo aux cosmétiques, en passant par les boissons.  Le groupe de cosmétiques Estée Lauder, par exemple, estime l'impact de ces droits de douane à environ 100 millions de dollars sur son exercice 2026.</p><p>En conclusion, l'augmentation des prix de la PlayStation 5 et la perspective d'une hausse des prix chez PepsiCo illustrent l'impact concret des droits de douane américains sur les entreprises et les consommateurs.  Ces mesures protectionnistes ont des répercussions importantes sur les coûts de production et obligent les entreprises à répercuter ces surcoûts sur les prix de vente.</p>
+      </section>
+
+      
+      <section class="key-points mt-12 p-6 bg-gray-100 rounded-lg">
+        <h3 class="text-2xl font-bold mb-4">Points clés</h3>
+        <ul class="list-disc list-inside space-y-2">
+          
+          <li>Sony augmente le prix de la PS5 de 50 dollars aux États-Unis.</li>
+          
+          <li>PepsiCo prévoit une hausse d'environ 10% sur ses boissons gazeuses.</li>
+          
+          <li>Ces augmentations sont une conséquence directe des droits de douane américains.</li>
+          
+        </ul>
+      </section>
+      
+    </article>
+</div>
+
+    </main>
+
+    <footer id="footer" class="bg-gray-800 text-gray-300 mt-16">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
+                </div>
+            <div class="mt-8 border-t border-gray-700 pt-8 flex justify-between items-center">
+                <p class="text-sm text-gray-500">&copy; 2025 L'Horizon Libre. Tous droits réservés.</p>
+                <div class="flex space-x-4"><a href="https://x.com/MediaHorizonL" class="text-gray-400 hover:text-white"><i data-feather="twitter"></i></a></div>
+            </div>
+        </div>
+    </footer>
+    
+    <script>
+        feather.replace();
+        // ... ajoute ici le reste de tes scripts globaux ...
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Cet article a été généré automatiquement par Aurore et sera fusionné dans 30 secondes.