### PR TITLE
Proposition d'article : Genève: Nouvelle stratégie économique cantonale axée sur l'innovation et les secteurs porteurs

### DIFF
--- a/article/gen-ve-nouvelle-strat-gie-conomique-cantonale-ax-e-sur-l-innovation-et-les-secte.html
+++ b/article/gen-ve-nouvelle-strat-gie-conomique-cantonale-ax-e-sur-l-innovation-et-les-secte.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Genève: Nouvelle stratégie économique cantonale axée sur l'innovation et les secteurs porteurs | L’Horizon Libre</title>
+    
+    <link rel="icon" href="data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='48' fill='%23B91C1C' stroke='%23111827' stroke-width='2'/%3E%3Cg transform='translate(50, 50) scale(0.65) translate(-55, -55)'%3E%3Cpath d='M 10 85 Q 55 100 85 25 Q 70 50 50 55 Q 25 75 10 85 Z' fill='white'/%3E%3Cpath d='M 78 32 Q 95 25 95 15 L 85 25 Z' fill='%231E40AF'/%3E%3C/g%3E%3C/svg%3E">
+    
+  <meta name="description" content="Genève présente sa nouvelle stratégie économique pour la prochaine décennie, axée sur l'innovation et des secteurs porteurs comme les sciences de la vie et le numérique. Un plan d'action précisera les mesures concrètes à mettre en œuvre dès 2026.">
+  <meta name="category" content="politique">
+  <meta name="keywords" content="Genève, économie, stratégie, innovation, sciences de la vie, industries créatives, numérique">
+  <meta property="og:title" content="Genève: Nouvelle stratégie économique cantonale axée sur l'innovation et les secteurs porteurs">
+  <meta property="og:description" content="Genève présente sa nouvelle stratégie économique pour la prochaine décennie, axée sur l'innovation et des secteurs porteurs comme les sciences de la vie et le numérique. Un plan d'action précisera les mesures concrètes à mettre en œuvre dès 2026.">
+
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <script src="https://unpkg.com/feather-icons"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; scroll-behavior: smooth; }
+        .article-card-img { height: 12rem; width: 100%; object-fit: cover; }
+        /* Ajoute ici d'autres styles globaux si tu le souhaites */
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    
+    <header class="bg-white shadow-sm sticky top-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-2">
+                <div class="flex items-center">
+                    <a href="/" title="Accueil - L'Horizon Libre">
+                        <svg class="h-14 sm:h-16 w-auto" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+                            <defs><style> .serif-final { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 20px; fill: #111827;} </style></defs>
+                            <rect y="50" width="200" height="4" fill="#1E40AF"/>
+                            <circle cx="100" cy="50" r="30" fill="#B91C1C"/>
+                            <g transform="translate(100, 50) scale(0.5) translate(-55, -55)">
+                                <path d="M 10 85 Q 55 100 85 25 Q 70 50 50 55 Q 25 75 10 85 Z" fill="white"/>
+                                <path d="M 78 32 Q 95 25 95 15 L 85 25 Z" fill="#1E40AF"/>
+                            </g>
+                            <text x="50" y="85" class="serif-final">L'Horizon Libre</text>
+                        </svg>
+                    </a>
+                </div>
+                <nav class="hidden md:flex items-center space-x-8">
+                    <a href="/" class="text-gray-600 hover:text-blue-800 transition">Accueil</a>
+                    <a href="/politique.html" class="text-gray-600 hover:text-blue-800 transition">Politique</a>
+                    <a href="/culture.html" class="text-gray-600 hover:text-blue-800 transition">Culture</a>
+                    <a href="/technologie.html" class="text-gray-600 hover:text-blue-800 transition">Tech</a>
+                    <a href="/a-propos.html" class="text-gray-600 hover:text-blue-800 transition">À Propos</a>
+                    <a href="/contact.html" class="text-gray-600 hover:text-blue-800 transition">Contact</a>
+                </nav>
+                <div><a href="#newsletter" class="bg-blue-800 text-white px-4 py-2 rounded-lg hover:bg-blue-900 transition text-sm font-semibold">Newsletter</a></div>
+            </div>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
+        
+<div class="max-w-4xl mx-auto">
+    <article>
+      <header class="mb-8 text-center">
+        <h1 class="text-3xl md:text-5xl font-bold">Genève: Nouvelle stratégie économique cantonale axée sur l'innovation et les secteurs porteurs</h1>
+        <p class="text-lg text-gray-600 mt-4">Le canton de Genève dévoile sa stratégie économique pour la décennie à venir, privilégiant les sciences de la vie, les industries créatives et le numérique.  Un plan d'action avec des mesures concrètes est attendu pour fin 2025.</p>
+        <time class="text-sm text-gray-500 mt-4 block" datetime="2025-08-21T15:45:58.368134+00:00">21 August 2025</time>
+      </header>
+      
+      
+      <figure class="my-8">
+        <img src="https://images.unsplash.com/photo-1599082323832-2676eca28e86?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3OTI2MjN8MHwxfHNlYXJjaHwxfHxHZW4lQzMlQTh2ZSUzQSUyME5vdXZlbGxlJTIwc3RyYXQlQzMlQTlnaWUlMjAlQzMlQTljb25vbWlxdWUlMjBjYW50b25hbGUlMjBheCVDMyVBOWUlMjBzdXIlMjBsJTI3aW5ub3ZhdGlvbiUyMGV0JTIwbGVzJTIwc2VjdGV1cnMlMjBwb3J0ZXVyc3xlbnwwfHx8fDE3NTU3OTExNTh8MA&ixlib=rb-4.1.0&q=80&w=1080" alt="Genève: Nouvelle stratégie économique cantonale axée sur l'innovation et les secteurs porteurs" class="article-featured-image shadow-lg">
+        <figcaption class="text-xs text-gray-500 text-center mt-2">
+          Photo par <a href="https://unsplash.com/@rickpsd">Henrique Ferreira</a> sur <a href="https://unsplash.com">Unsplash</a>
+        </figcaption>
+      </figure>
+      
+
+      <section class="prose prose-lg max-w-none">
+        <p>Face aux défis économiques actuels, le canton de Genève a présenté sa nouvelle stratégie économique pour les dix prochaines années.  Remplaçant le plan de 2015, ce document, validé par le Conseil d’État et porté par la conseillère d’État Delphine Bachmann,  adopte une approche pragmatique, axée sur les réalités du tissu économique genevois.</p><p>Contrairement à la précédente stratégie jugée trop générale, la nouvelle approche se concentre sur des secteurs porteurs tels que les sciences de la vie, les industries créatives et le numérique.  Ces choix stratégiques sont justifiés par une analyse approfondie du marché genevois.  Des mesures concrètes, dont l’étude de crédits d’impôt remboursables pour certaines entreprises, sont envisagées et seront détaillées dans un plan d’action prévu pour fin 2025, avec une mise en œuvre dès 2026.  Le renforcement des conditions-cadres, l’accompagnement des entreprises face aux transitions (écologique, numérique, démographique) et l’accroissement de la visibilité internationale de Genève sont également au cœur de cette stratégie.</p><p>Malgré une consultation de 140 acteurs, la liste des participants n'a pas été rendue publique, soulevant des questions sur la transparence de la démarche.  Si la stratégie ne cible pas directement les secteurs en difficulté comme le commerce non alimentaire, le canton mise sur un effet d’entraînement positif généré par la croissance des secteurs prioritaires.  L’Office cantonal de l’économie pilotera la mise en œuvre de cette stratégie, sans allocation de nouveaux fonds, mais plutôt par une repriorisation des ressources existantes.  L’objectif affiché est clair : préserver la prospérité et l’attractivité du canton face aux incertitudes économiques.</p>
+      </section>
+
+      
+      <section class="key-points mt-12 p-6 bg-gray-100 rounded-lg">
+        <h3 class="text-2xl font-bold mb-4">Points clés</h3>
+        <ul class="list-disc list-inside space-y-2">
+          
+          <li>Nouvelle stratégie économique genevoise pour la décennie à venir.</li>
+          
+          <li>Secteurs prioritaires: sciences de la vie, industries créatives et numérique.</li>
+          
+          <li>Plan d'action avec mesures concrètes (dont crédits d'impôt) attendu fin 2025.</li>
+          
+        </ul>
+      </section>
+      
+    </article>
+</div>
+
+    </main>
+
+    <footer id="footer" class="bg-gray-800 text-gray-300 mt-16">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
+                </div>
+            <div class="mt-8 border-t border-gray-700 pt-8 flex justify-between items-center">
+                <p class="text-sm text-gray-500">&copy; 2025 L'Horizon Libre. Tous droits réservés.</p>
+                <div class="flex space-x-4"><a href="https://x.com/MediaHorizonL" class="text-gray-400 hover:text-white"><i data-feather="twitter"></i></a></div>
+            </div>
+        </div>
+    </footer>
+    
+    <script>
+        feather.replace();
+        // ... ajoute ici le reste de tes scripts globaux ...
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Cet article a été généré automatiquement par Aurore et sera fusionné dans 30 secondes.