### PR TITLE
Proposition d'article : Retour de Ken Jäger au HC Davos: Un contrat de sept ans pour l'attaquant suisse

### DIFF
--- a/article/retour-de-ken-j-ger-au-hc-davos-un-contrat-de-sept-ans-pour-l-attaquant-suisse.html
+++ b/article/retour-de-ken-j-ger-au-hc-davos-un-contrat-de-sept-ans-pour-l-attaquant-suisse.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retour de Ken Jäger au HC Davos: Un contrat de sept ans pour l'attaquant suisse | L’Horizon Libre</title>
+    
+    <link rel="icon" href="data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='48' fill='%23B91C1C' stroke='%23111827' stroke-width='2'/%3E%3Cg transform='translate(50, 50) scale(0.65) translate(-55, -55)'%3E%3Cpath d='M 10 85 Q 55 100 85 25 Q 70 50 50 55 Q 25 75 10 85 Z' fill='white'/%3E%3Cpath d='M 78 32 Q 95 25 95 15 L 85 25 Z' fill='%231E40AF'/%3E%3C/g%3E%3C/svg%3E">
+    
+  <meta name="description" content="Ken Jäger, double médaillé d'argent mondial, revient au HC Davos pour un contrat de sept ans après une période de cinq ans au Lausanne HC.  Ce retour marque un tournant important dans sa carrière et renforce les ambitions du club grison.">
+  <meta name="category" content="sport">
+  <meta name="keywords" content="Ken Jäger, HC Davos, Lausanne HC, hockey sur glace, National League, Championnat du monde">
+  <meta property="og:title" content="Retour de Ken Jäger au HC Davos: Un contrat de sept ans pour l'attaquant suisse">
+  <meta property="og:description" content="Ken Jäger, double médaillé d'argent mondial, revient au HC Davos pour un contrat de sept ans après une période de cinq ans au Lausanne HC.  Ce retour marque un tournant important dans sa carrière et renforce les ambitions du club grison.">
+
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <script src="https://unpkg.com/feather-icons"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; scroll-behavior: smooth; }
+        .article-card-img { height: 12rem; width: 100%; object-fit: cover; }
+        /* Ajoute ici d'autres styles globaux si tu le souhaites */
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    
+    <header class="bg-white shadow-sm sticky top-0 z-50">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center py-2">
+                <div class="flex items-center">
+                    <a href="/" title="Accueil - L'Horizon Libre">
+                        <svg class="h-14 sm:h-16 w-auto" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+                            <defs><style> .serif-final { font-family: 'Playfair Display', serif; font-weight: 700; font-size: 20px; fill: #111827;} </style></defs>
+                            <rect y="50" width="200" height="4" fill="#1E40AF"/>
+                            <circle cx="100" cy="50" r="30" fill="#B91C1C"/>
+                            <g transform="translate(100, 50) scale(0.5) translate(-55, -55)">
+                                <path d="M 10 85 Q 55 100 85 25 Q 70 50 50 55 Q 25 75 10 85 Z" fill="white"/>
+                                <path d="M 78 32 Q 95 25 95 15 L 85 25 Z" fill="#1E40AF"/>
+                            </g>
+                            <text x="50" y="85" class="serif-final">L'Horizon Libre</text>
+                        </svg>
+                    </a>
+                </div>
+                <nav class="hidden md:flex items-center space-x-8">
+                    <a href="/" class="text-gray-600 hover:text-blue-800 transition">Accueil</a>
+                    <a href="/politique.html" class="text-gray-600 hover:text-blue-800 transition">Politique</a>
+                    <a href="/culture.html" class="text-gray-600 hover:text-blue-800 transition">Culture</a>
+                    <a href="/technologie.html" class="text-gray-600 hover:text-blue-800 transition">Tech</a>
+                    <a href="/a-propos.html" class="text-gray-600 hover:text-blue-800 transition">À Propos</a>
+                    <a href="/contact.html" class="text-gray-600 hover:text-blue-800 transition">Contact</a>
+                </nav>
+                <div><a href="#newsletter" class="bg-blue-800 text-white px-4 py-2 rounded-lg hover:bg-blue-900 transition text-sm font-semibold">Newsletter</a></div>
+            </div>
+        </div>
+    </header>
+
+    <main class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
+        
+<div class="max-w-4xl mx-auto">
+    <article>
+      <header class="mb-8 text-center">
+        <h1 class="text-3xl md:text-5xl font-bold">Retour de Ken Jäger au HC Davos: Un contrat de sept ans pour l'attaquant suisse</h1>
+        <p class="text-lg text-gray-600 mt-4">Après cinq saisons passées au Lausanne HC, Ken Jäger retourne au club formateur, le HC Davos, pour un contrat de sept ans.  Ce retour marque un tournant important dans la carrière de l'attaquant international suisse, double médaillé d'argent mondial.</p>
+        <time class="text-sm text-gray-500 mt-4 block" datetime="2025-08-24T10:21:59.539061+00:00">24 August 2025</time>
+      </header>
+      
+      
+      <figure class="my-8">
+        <img src="https://images.unsplash.com/photo-1709745059456-51c2052f29af?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3OTI2MjN8MHwxfHNlYXJjaHwxfHxSZXRvdXIlMjBkZSUyMEtlbiUyMEolQzMlQTRnZXIlMjBhdSUyMEhDJTIwRGF2b3MlM0ElMjBVbiUyMGNvbnRyYXQlMjBkZSUyMHNlcHQlMjBhbnMlMjBwb3VyJTIwbCUyN2F0dGFxdWFudCUyMHN1aXNzZXxlbnwwfHx8fDE3NTYwMzA5MTl8MA&ixlib=rb-4.1.0&q=80&w=1080" alt="Retour de Ken Jäger au HC Davos: Un contrat de sept ans pour l'attaquant suisse" class="article-featured-image shadow-lg">
+        <figcaption class="text-xs text-gray-500 text-center mt-2">
+          Photo par <a href="https://unsplash.com/@jordidimass">jordi</a> sur <a href="https://unsplash.com">Unsplash</a>
+        </figcaption>
+      </figure>
+      
+
+      <section class="prose prose-lg max-w-none">
+        <p>Ken Jäger, attaquant international suisse, a annoncé son retour au HC Davos pour la saison 2026-2027.  Ce transfert marque la fin de son aventure de cinq ans au Lausanne HC, où il a notamment atteint deux finales des séries éliminatoires.  Le joueur, formé au sein même du club grison, a signé un contrat de sept ans, un engagement de long terme qui témoigne de la confiance réciproque entre le joueur et le club.</p><p>Formé au HC Davos, Jäger a fait ses débuts en National League avec l'équipe en 2016-2017.  Après une expérience de deux ans en Suède, il a rejoint le Lausanne HC en 2020.  Son parcours au sein du Lausanne HC a été marqué par de belles performances, contribuant significativement à la réussite de l'équipe.  Son retour à Davos représente un choix important dans sa carrière, un retour aux sources pour cet attaquant expérimenté et reconnu.</p><p>Sur la scène internationale, Ken Jäger a brillé avec l'équipe nationale suisse.  Il a remporté deux médailles d'argent lors des Championnats du monde, en 2024 et 2025.  Ces performances confirment son talent et son niveau de jeu élevé.  Son retour au HC Davos devrait renforcer considérablement l'effectif du club et contribuer à ses ambitions pour les prochaines saisons.  Ce contrat de sept ans représente un investissement à long terme pour le club, qui mise sur l'expérience et le talent de Jäger pour atteindre ses objectifs.</p><p>Ce retour au bercail est une nouvelle importante pour le hockey suisse.  L'arrivée de Ken Jäger au HC Davos promet d'être un atout majeur pour le club.  Son expérience, son talent et son palmarès international seront des atouts précieux pour l'équipe. L'impact de ce retour sur les performances du HC Davos et sur le championnat de National League reste à observer.</p>
+      </section>
+
+      
+      <section class="key-points mt-12 p-6 bg-gray-100 rounded-lg">
+        <h3 class="text-2xl font-bold mb-4">Points clés</h3>
+        <ul class="list-disc list-inside space-y-2">
+          
+          <li>Ken Jäger signe un contrat de sept ans avec le HC Davos.</li>
+          
+          <li>Il retourne au club formateur après cinq saisons au Lausanne HC.</li>
+          
+          <li>Jäger est double médaillé d'argent mondial avec l'équipe de Suisse.</li>
+          
+        </ul>
+      </section>
+      
+    </article>
+</div>
+
+    </main>
+
+    <footer id="footer" class="bg-gray-800 text-gray-300 mt-16">
+        <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
+                </div>
+            <div class="mt-8 border-t border-gray-700 pt-8 flex justify-between items-center">
+                <p class="text-sm text-gray-500">&copy; 2025 L'Horizon Libre. Tous droits réservés.</p>
+                <div class="flex space-x-4"><a href="https://x.com/MediaHorizonL" class="text-gray-400 hover:text-white"><i data-feather="twitter"></i></a></div>
+            </div>
+        </div>
+    </footer>
+    
+    <script>
+        feather.replace();
+        // ... ajoute ici le reste de tes scripts globaux ...
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Cet article a été généré automatiquement par Aurore et sera fusionné dans 30 secondes.